### PR TITLE
removing deprecated and redundant tsc package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "waxpeer",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
         "@types/node": "^18.11.13",
@@ -15,13 +15,12 @@
         "limiter": "^2.1.0",
         "qs": "^6.11.0",
         "socket.io-client": "^2.5.0",
-        "tsc": "^1.20150623.0",
+        "typescript": "^3.9.10",
         "ws": "^8.11.0"
       },
       "devDependencies": {
         "ts-node": "^10.9.1",
-        "tsc-watch": "^6.0.0",
-        "typescript": "^3.6.3"
+        "tsc-watch": "^6.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -694,16 +693,6 @@
         }
       }
     },
-    "node_modules/tsc": {
-      "version": "1.20150623.0",
-      "resolved": "https://registry.npmjs.org/tsc/-/tsc-1.20150623.0.tgz",
-      "integrity": "sha512-35dAbChm97r03rxlfPwkFrrI8WoFlrqtbskmxomtnso2fOSKWDLt3TitT2ZNHl5hQF1Su9S9w/vjmoXf5W0VWA==",
-      "deprecated": "you probably meant to install typescript",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      }
-    },
     "node_modules/tsc-watch": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-6.0.0.tgz",
@@ -729,7 +718,6 @@
       "version": "3.9.10",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
       "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1335,11 +1323,6 @@
         "yn": "3.1.1"
       }
     },
-    "tsc": {
-      "version": "1.20150623.0",
-      "resolved": "https://registry.npmjs.org/tsc/-/tsc-1.20150623.0.tgz",
-      "integrity": "sha512-35dAbChm97r03rxlfPwkFrrI8WoFlrqtbskmxomtnso2fOSKWDLt3TitT2ZNHl5hQF1Su9S9w/vjmoXf5W0VWA=="
-    },
     "tsc-watch": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-6.0.0.tgz",
@@ -1355,8 +1338,7 @@
     "typescript": {
       "version": "3.9.10",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-      "dev": true
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "dev": "tsc-watch --onSuccess \"node ./dist/test.js\"",
-    "build": "tsc",
-    "push": "tsc && npm publish --access public"
+    "dev": "./node_modules/.bin/tsc-watch --onSuccess \"node ./dist/test.js\"",
+    "build": "./node_modules/.bin/tsc",
+    "push": "./node_modules/.bin/tsc && npm publish --access public"
   },
   "repository": {
     "type": "git",
@@ -30,8 +30,7 @@
   "homepage": "https://github.com/skylight-ity/waxpeer#readme",
   "devDependencies": {
     "ts-node": "^10.9.1",
-    "tsc-watch": "^6.0.0",
-    "typescript": "^3.6.3"
+    "tsc-watch": "^6.0.0"
   },
   "dependencies": {
     "@types/node": "^18.11.13",
@@ -40,7 +39,7 @@
     "limiter": "^2.1.0",
     "qs": "^6.11.0",
     "socket.io-client": "^2.5.0",
-    "tsc": "^1.20150623.0",
+    "typescript": "^3.9.10",
     "ws": "^8.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "dev": "./node_modules/.bin/tsc-watch --onSuccess \"node ./dist/test.js\"",
-    "build": "./node_modules/.bin/tsc",
-    "push": "./node_modules/.bin/tsc && npm publish --access public"
+    "dev": "npx tsc-watch --onSuccess \"node ./dist/test.js\"",
+    "build": "npx tsc",
+    "push": "npx tsc && npm publish --access public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `tsc` package is long deprecated and not useful here.

The correct package that provides the wanted `tsc` CLI command is `typescript`, which is already included in the package.json _(that I also updated)_.