### PR TITLE
updating the tradeSocket state logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waxpeer",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Waxpeer API wrapper for NodeJs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Added a socket state check on sending a ping. 
Added cleaning of ping interval on disconnect.
Improved state checks, removed possible infinite loop of reconnection when spamming in connect/disconnect methods. 
Connection now terminate all unopened socket states. 