### PR TITLE
Fix `checkItemAvailability` typings

### DIFF
--- a/src/waxpeer.ts
+++ b/src/waxpeer.ts
@@ -555,7 +555,7 @@ export class Waxpeer {
    */
   public checkItemAvailability(
     item_id: string | number | string[] | number[],
-  ): Promise<{ success: boolean; data: IAvailable[] }> {
+  ): Promise<{ success: boolean; items: IAvailable[] }> {
     let ids = typeof item_id === 'object' ? item_id : [item_id];
     return this.get(`check-availability`, ids.map((i) => `item_id=${i}`).join('&'));
   }


### PR DESCRIPTION
[`/check-availability`](https://api.waxpeer.com/docs/#/Buy%20items/get_v1_check_availability) endpoint returns `success` and `items` rather than `success` and `data`

Temporary fix:

```ts
const result = await this.waxpeer.checkItemAvailability([/* ... */])
// @ts-expect-error invalid waxpeer library typings
const items = result.items as Awaited<ReturnType<Waxpeer['checkItemAvailability']>>['data']
```